### PR TITLE
Fix btest config: Merge two IgnoreFiles lines

### DIFF
--- a/tests/btest.cfg
+++ b/tests/btest.cfg
@@ -5,8 +5,7 @@ TestDirs=hilti binpac
 TmpDir      = %(testbase)s/.tmp
 BaselineDir = %(testbase)s/Baseline
 IgnoreDirs  = .svn CVS .tmp Baseline Failing
-IgnoreFiles = *.tmp *.swp .*.swp #*
-IgnoreFiles = *.pcap data.* *.dat *.wmv *.der
+IgnoreFiles = *.pcap data.* *.dat *.wmv *.der *.tmp *.swp .*.swp #*
 
 Finalizer   = %(testbase)s/Scripts/finalizer
 


### PR DESCRIPTION
Temporary Vim files were not ignored because in <code>btest.cfg</code>, the second <code>IgnoreFiles</code> line overrides the first one.

Steps to reproduce:
- <code>vim tests/binpac/addr/basic.pac2</code>
- <code>btest</code> fails with <code>/opt/hilti/tests/binpac/addr/.basic.pac2.swp: mandatory exec command not found.</code>
