### PR TITLE
Fix header flags in dns.pac2 and add RFC 2535 bits

### DIFF
--- a/libbinpac/parsers/dns.pac2
+++ b/libbinpac/parsers/dns.pac2
@@ -24,13 +24,14 @@ type Header = unit {
     id : uint16;
        : bitfield(16) {
             qr: 0;
-            opcode: 1..3;
-            aa: 4;
-            tc: 5;
-            rd: 6;
-            ra: 7;
-            _pad: 8;
-            z:  9..11;
+            opcode: 1..4;
+            aa: 5;
+            tc: 6;
+            rd: 7;
+            ra: 8;
+            z:  9;
+            ad: 10;
+            cd: 11;
             rcode: 12..15;
         };
 


### PR DESCRIPTION
- RFC 1035 section 4.1.1 specifies that the opcode has 4 bits.
  There is no extra padding bit.
- Add the AD and CD bits introduced by RFC 2535 (section 6.1.1).
  They use two of the three original Z bits.
