### PR TITLE
Select clang version with LLVM_CONFIG_EXEC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ all: release
 
 debug:
 	test -d build || mkdir build
-	( cd build; test -e Makefile || cmake  -D CMAKE_BUILD_TYPE=Debug -D BRO_DIST=$${BRO_DIST} ..; $(MAKE) )
+	( cd build; test -e Makefile || cmake  -D CMAKE_BUILD_TYPE=Debug -D BRO_DIST=$${BRO_DIST} -D LLVM_CONFIG_EXEC=$${LLVM_CONFIG_EXEC} ..; $(MAKE) )
 
 release:
 	test -d build || mkdir build
-	( cd build; test -e Makefile || cmake  -D CMAKE_BUILD_TYPE=RelWithDebInfo -D BRO_DIST=$${BRO_DIST} ..; $(MAKE) )
+	( cd build; test -e Makefile || cmake  -D CMAKE_BUILD_TYPE=RelWithDebInfo -D BRO_DIST=$${BRO_DIST} -D LLVM_CONFIG_EXEC=$${LLVM_CONFIG_EXEC} ..; $(MAKE) )
 
 clean:
 	rm -rf build

--- a/cmake/EnableLLVMBitcode.cmake
+++ b/cmake/EnableLLVMBitcode.cmake
@@ -18,6 +18,7 @@ set(CMAKE_STATIC_LIBRARY_SUFFIX ".bc")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -emit-llvm")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -emit-llvm")
+set(ENV{LLVM_CONFIG_EXEC} ${LLVM_CONFIG_EXEC})
 set(CMAKE_AR "${scripts}/llvm-ar-wrapper")
 set(CMAKE_RANLIB "${scripts}/llvm-ranlib-wrapper")
 # set(CMAKE_LD "llvm-ld")

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -41,6 +41,9 @@ if (LLVM_INCLUDE_DIR)
   set(LLVM_FOUND TRUE)
 
 else ()
+  if(LLVM_CONFIG_EXEC STREQUAL "")
+    unset(LLVM_CONFIG_EXEC CACHE)
+  endif()
 
   find_program(LLVM_CONFIG_EXEC
       NAMES llvm-config

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -47,14 +47,18 @@ else ()
       PATHS /opt/local/bin /opt/llvm/bin
   )
 
+  exec_program(${LLVM_CONFIG_EXEC} ARGS --bindir     OUTPUT_VARIABLE LLVM_BIN_DIR)
+
   find_program(LLVM_CLANG_EXEC
       NAMES clang
-      PATHS /opt/local/bin  /opt/llvm/bin
+      PATHS ${LLVM_BIN_DIR}
+      NO_DEFAULT_PATH
   )
 
   find_program(LLVM_CLANGXX_EXEC
       NAMES clang++
-      PATHS /opt/local/bin  /opt/llvm/bin
+      PATHS ${LLVM_BIN_DIR}
+      NO_DEFAULT_PATH
   )
 
   set(LLVM_FOUND TRUE)

--- a/scripts/llvm-ar-wrapper
+++ b/scripts/llvm-ar-wrapper
@@ -5,6 +5,12 @@ output=$1
 shift
 inputs=$@
 
-llvm-link -o $output $inputs
+LLVM_LINK=llvm-link
+
+if [ "$LLVM_CONFIG_EXEC" ]; then
+    LLVM_BIN_PATH=`$LLVM_CONFIG_EXEC --bindir`
+    LLVM_LINK=$LLVM_BIN_PATH/llvm-link
+fi
+$LLVM_LINK -o $output $inputs
 
 

--- a/tools/hilti-build
+++ b/tools/hilti-build
@@ -13,7 +13,17 @@ Version = 0.2
 
 Target = "<unknown>"
 
-Cc           = "clang -gfull"                    # Note, we really need clang.
+llvm_config = os.environ.get("LLVM_CONFIG_EXEC")
+if llvm_config:
+    try:
+        bindir = subprocess.Popen([llvm_config, "--bindir"], stdout=subprocess.PIPE).communicate()[0].strip()
+        Cc   = "%s/clang -gfull" % bindir
+    except:
+	print >>sys.strerr, "Error when executing llvm_config with LLVM_CONFIG_EXEC (%s)" % llvm_config
+	exit(-1)
+else:
+    Cc       = "clang -gfull"                    # Note, we really need clang.
+
 CcOptSpec    = "-O2"                             # With clang, -O4 is LTO, which we can't do wo/ support by the system linker.
 OptOptSpec   = "-std-compile-opts -std-link-opts -disable-internalize"
 


### PR DESCRIPTION
Patch to select the clang version used to build Hilti. Useful to use a different version of the system.
For instance :

```
make LLVM_CONFIG_EXEC=/opt/llvm-3.5/bin/llvm-config
```

or

```
make LLVM_CONFIG_EXEC=$(which llvm-config-3.5)
```

Some modifications had to be done in scripts (llvm-ar-wrapper and hilti-build) to take account of the llvm-config to use.

(Idea inspired by ldc project and its clang version matrix https://github.com/ldc-developers/ldc/blob/master/.travis.yml)
