### PR TITLE
Remove -f flag from "docker tag" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ docker-build:
 
 docker-build-internal:
 	docker build -t $(DOCKER_TAG):$(DOCKER_VERSION) -f Dockerfile .
-	docker tag -f $$(docker inspect --format='{{.Id}}' $(DOCKER_TAG):$(DOCKER_VERSION)) $(DOCKER_TAG):latest
+	docker tag $$(docker inspect --format='{{.Id}}' $(DOCKER_TAG):$(DOCKER_VERSION)) $(DOCKER_TAG):latest
 
 docker-run:
 	docker run -i -t ${DOCKER_TAG}:latest


### PR DESCRIPTION
Newer Docker versions (since v1.12.0) do not support
the -f flag on the "docker tag" command anymore.
This causes our command to fail on these systems.

Remove the flag since it is implied now.
https://docs.docker.com/engine/deprecated/