### PR TITLE
Remove note regarding BinPAC++ from Spicy doc

### DIFF
--- a/doc/spicy/index.rst
+++ b/doc/spicy/index.rst
@@ -3,14 +3,6 @@
 Spicy: A Parser Generator For Network Protocols
 ==================================================
 
-.. note::
-   As you work with Spicy, you'll see a different name pop up
-   sometimes: *Spicy*, which is Spicy's early name from when the
-   project started. We have since renamed the system, as it is not
-   really related to the original Spicy system at all. However, as
-   the renaming remains a work in progress, Spicy's tools and source
-   code still use the old terminology for the most part.
-
 Table of Contents:
 
 .. toctree::


### PR DESCRIPTION
Since Spicy version 0.5 all tools have been renamed
and there is no reference to BinPAC++ in the code.
So we can delete the note. A hint is still left
on the HILTI home page.