### PR TITLE
Set fixed timezone for timezone-dependent tests

### DIFF
--- a/tests/spicy/libspicy/mktime.spicy
+++ b/tests/spicy/libspicy/mktime.spicy
@@ -1,6 +1,6 @@
 #
 # @TEST-EXEC:  hilti-build %INPUT -o a.out
-# @TEST-EXEC:  ./a.out >output 2>&1
+# @TEST-EXEC:  TZ=America/Los_Angeles ./a.out >output 2>&1
 # @TEST-EXEC:  btest-diff output
 
 module Test;

--- a/tests/spicy/parsers/zip/test.spicy
+++ b/tests/spicy/parsers/zip/test.spicy
@@ -1,5 +1,5 @@
 #
-# @TEST-EXEC:  cat %DIR/archive.zip.dat | spicy-driver-test -I ${PARSERS} ${PARSERS}/mstime.spicy ${PARSERS}/zip.spicy %INPUT -- -p ZIP::Archive >output
+# @TEST-EXEC:  export TZ=America/Los_Angeles; cat %DIR/archive.zip.dat | spicy-driver-test -I ${PARSERS} ${PARSERS}/mstime.spicy ${PARSERS}/zip.spicy %INPUT -- -p ZIP::Archive >output
 # @TEST-EXEC:  btest-diff output
 #
 


### PR DESCRIPTION
Since mktime output depends on the local timezone,
some tests failed when run in a different timezone
as the original baseline (America/Los_Angeles):

```
$ date
Fri Jan 13 10:02:18 UTC 2017
$ btest -d spicy/libspicy/mktime.spicy
[  0%] spicy.libspicy.mktime ... failed
  % 'btest-diff output' failed unexpectedly (exit code 1)
  % cat .diag
  == File ===============================
  2000-01-02T03:04:05.000000000Z
  == Diff ===============================
  --- /tmp/test-diff.1901.output.baseline.tmp   2017-01-13 10:03:10.465994522 +0000
  +++ /tmp/test-diff.1901.output.tmp    2017-01-13 10:03:10.505964836 +0000
  @@ -1 +1 @@
  -2000-01-02T11:04:05.000000000Z
  +2000-01-02T03:04:05.000000000Z
  =======================================

  % cat .stderr

1 of 1 test failed
```